### PR TITLE
ci: :construction_worker: trying to fix `the input device is not a TTY`

### DIFF
--- a/bin/docker-quality
+++ b/bin/docker-quality
@@ -3,5 +3,5 @@
 set -e
 
 docker-compose up --detach
-docker-compose exec app bin/quality
+docker-compose exec -T app bin/quality
 docker-compose stop

--- a/bin/docker-tests
+++ b/bin/docker-tests
@@ -1,6 +1,6 @@
 #!/usr/bin/env sh
 
 docker-compose up --detach
-docker-compose exec app bin/rails db:schema:load
-docker-compose exec app bin/tests ${@:-spec}
+docker-compose exec -T app bin/rails db:schema:load
+docker-compose exec -T app bin/tests ${@:-spec}
 docker-compose stop


### PR DESCRIPTION
- trying to fix `the input device is not a TTY`