### PR TITLE
security: :shield: fix CVE-2022-24790

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ gem 'rails', '~> 7.0.2'
 gem 'pg', '~> 1.1'
 
 # Use the Puma web server [https://github.com/puma/puma]
-gem 'puma', ">=  5.6.2"
+gem 'puma', ">= 5.6.4"
 
 # A pure ruby implementation of JWT standard
 gem 'jwt', '~> 2.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -235,7 +235,7 @@ GEM
       coderay (~> 1.1)
       method_source (~> 1.0)
     public_suffix (4.0.6)
-    puma (5.6.2)
+    puma (5.6.4)
       nio4r (~> 2.0)
     pundit (2.2.0)
       activesupport (>= 3.0.0)
@@ -464,7 +464,7 @@ DEPENDENCIES
   parser (~> 3.0, >= 3.0.2.0)
   pg (~> 1.1)
   pry (~> 0.14.1)
-  puma (>= 5.6.2)
+  puma (>= 5.6.4)
   pundit (~> 2.1, >= 2.1.1)
   rack-attack (~> 6.6)
   rack-cors


### PR DESCRIPTION
- Bump `puma` version to `5.6.4`;