### PR TITLE
refactor: :recycle: improve authentication & authorization error handling

### DIFF
--- a/app/controllers/api/v1/concerns/error_handler.rb
+++ b/app/controllers/api/v1/concerns/error_handler.rb
@@ -7,7 +7,7 @@ module Api::V1::Concerns::ErrorHandler
     rescue_from ActiveRecord::RecordNotFound, with: :render_not_found
     rescue_from JSON::ParserError, with: :render_bad_request
     rescue_from Pundit::NotAuthorizedError, with: :render_unauthorized
-    rescue_from Auth::NotAuthorizedError, with: :render_unauthorized
+    rescue_from Auth::BasicAuthError, with: :render_unauthorized_with_code
     rescue_from Auth::UnauthenticatedError, with: :render_unauthenticated
     rescue_from Roles::UndefinedRoleTypeError, with: :render_undefined_role_type
   end
@@ -25,9 +25,11 @@ module Api::V1::Concerns::ErrorHandler
   end
 
   def render_unauthorized(exception)
-    render_error_response 'Unauthorized',
-                          (exception.is_a?(Auth::NotAuthorizedError) ? exception.error_code : :unauthorized),
-                          exception.message
+    render_error_response 'Unauthorized', :unauthorized, exception.message
+  end
+
+  def render_unauthorized_with_code(exception)
+    render_error_response 'Unauthorized', exception.error_code, exception.message
   end
 
   def render_unauthenticated(exception)

--- a/app/controllers/api/v1/concerns/json_params.rb
+++ b/app/controllers/api/v1/concerns/json_params.rb
@@ -4,6 +4,8 @@ module Api::V1::Concerns::JsonParams
   private
 
   def json_params(attributes)
+    params.require(:data).require(:type)
+    params.require(:data).require(:attributes)
     params
       .require(:data)
       .permit(:type, { attributes: attributes })

--- a/app/policies/post_policy.rb
+++ b/app/policies/post_policy.rb
@@ -10,6 +10,8 @@ class PostPolicy < ApplicationPolicy
   private
 
   def manage?
+    @error_code = :forbidden
+
     require_user_in_good_standing!
 
     user.admin? ||

--- a/config/initializers/monkey_patches/pundit.rb
+++ b/config/initializers/monkey_patches/pundit.rb
@@ -1,0 +1,18 @@
+Pundit.module_eval do
+  class << self
+    def authorize(user, possibly_namespaced_record, query, policy_class: nil, cache: {})
+      record = pundit_model(possibly_namespaced_record)
+      policy = if policy_class then policy_class.new(user, record)
+               else cache[possibly_namespaced_record] ||= policy!(user, possibly_namespaced_record)
+               end
+
+      unless policy.public_send(query)
+        raise Auth::BasicAuthError,
+              error_code: policy.error_code,
+              query: query, record: record, policy: policy
+      end
+
+      record
+    end
+  end
+end

--- a/docs/contributing/resource_auth_scheme.md
+++ b/docs/contributing/resource_auth_scheme.md
@@ -1,0 +1,21 @@
+```
+  +-------------------+
+  | RESOURCE EXISTS ? |
+  +-------------------+
+    |       |
+ NO |       v YES
+    v      +-----------------------
+   404     | IS LOGGED-IN ? (authenticated)
+           +-----------------------
+              |              |
+           NO |              | YES
+              v              v
+              401            +-----------------------
+                             | CAN ACCESS RESOURCE ? (permission, authorized, ...)
+                             +-----------------------
+             redirect          |            |
+             to login       NO |            | YES
+                               |            |
+                               v            v
+                               403          OK 200, redirect, ...
+```

--- a/docs/swagger/v1/swagger.json
+++ b/docs/swagger/v1/swagger.json
@@ -1003,15 +1003,15 @@
                   "data": {
                     "type": "auth",
                     "attributes": {
-                      "access_token": "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOjEsImV4cCI6MTY1MDEzOTAxNSwianRpIjoiZDU5MWIxZDlhY2Q3ZDgyMzE5MTViMWU2YmZiMzRmYTEiLCJ0eXBlIjoiYWNjZXNzIn0.YTspLaIwOfZdQw3Y4XEv_QrZZbqQ8lojRgwzcsUEon8",
-                      "refresh_token": "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOjEsImV4cCI6MTY1MjcyNzQxNSwianRpIjoiZDU5MWIxZDlhY2Q3ZDgyMzE5MTViMWU2YmZiMzRmYTEiLCJ0eXBlIjoicmVmcmVzaCJ9.ShgK8z3ONurEV9nqvk-d4_La8rwkERgNx2qMPbHktqM",
+                      "access_token": "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOjEsImV4cCI6MTY1MDE5MzM1MSwianRpIjoiZGIyODczNmZiZjc1ODdlMjIyNWMxYTNjMTA5N2YwNWQiLCJ0eXBlIjoiYWNjZXNzIn0.Ke5pHtvRGf32BYsSJsxxYYzFSUwmZmG3Ni7OKLnHBac",
+                      "refresh_token": "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOjEsImV4cCI6MTY1Mjc4MTc1MSwianRpIjoiZGIyODczNmZiZjc1ODdlMjIyNWMxYTNjMTA5N2YwNWQiLCJ0eXBlIjoicmVmcmVzaCJ9.waiG4yWgOiePanazdFRrTElLoC9Qdzebcii6f0bpWHQ",
                       "me": {
                         "id": "1",
                         "type": "user",
                         "attributes": {
                           "email": "0@mail.com",
-                          "username": "Demeter21850",
-                          "created_at": "2022-04-16T18:56:55.299Z",
+                          "username": "Poseidon29494",
+                          "created_at": "2022-04-17T10:02:31.080Z",
                           "role": {
                             "name": "user",
                             "value": 0
@@ -1023,6 +1023,44 @@
                 },
                 "schema": {
                   "$ref": "#/components/schemas/response_auth_sign_in"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "invalid credentials",
+            "content": {
+              "application/json": {
+                "example": {
+                  "errors": [
+                    {
+                      "code": "unauthorized",
+                      "status": "401",
+                      "title": "Invalid credentials"
+                    }
+                  ]
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/invalid_credentials_error"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "param is missing",
+            "content": {
+              "application/json": {
+                "example": {
+                  "errors": [
+                    {
+                      "code": "unprocessable_entity",
+                      "status": "422",
+                      "title": "param is missing or the value is empty: attributes"
+                    }
+                  ]
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/param_is_missing"
                 }
               }
             }
@@ -1056,15 +1094,15 @@
                   "data": {
                     "type": "auth",
                     "attributes": {
-                      "access_token": "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOjIsImV4cCI6MTY1MDEzOTAxNSwianRpIjoiNjhlODI5MDU4OWY5ZjUwYmU4NTRhYzMxZmI2ZTM4ZDIiLCJ0eXBlIjoiYWNjZXNzIn0.6TAPTD5TCPTe8GlipyiiNom0k7PrE9IbOz9lIrFszMY",
-                      "refresh_token": "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOjIsImV4cCI6MTY1MjcyNzQxNSwianRpIjoiNjhlODI5MDU4OWY5ZjUwYmU4NTRhYzMxZmI2ZTM4ZDIiLCJ0eXBlIjoicmVmcmVzaCJ9.fokc6Y1q5CxZvNdPj3yPORJ4HXXoRcvuiQ8vOk6REPQ",
+                      "access_token": "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOjMsImV4cCI6MTY1MDE5MzM1MSwianRpIjoiYTZlNjczOGE5YmJlYjIzNzcxZmZjNzdlMjI0MWJjNmQiLCJ0eXBlIjoiYWNjZXNzIn0.q-8fR5qBg9WdKObdVby5-TdD7X1EuUs625WRINrVmzM",
+                      "refresh_token": "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOjMsImV4cCI6MTY1Mjc4MTc1MSwianRpIjoiYTZlNjczOGE5YmJlYjIzNzcxZmZjNzdlMjI0MWJjNmQiLCJ0eXBlIjoicmVmcmVzaCJ9.Byt72MFaO441y-LGh0UFhkTsr-fuvXcxnNDHINzuAsE",
                       "me": {
-                        "id": "2",
+                        "id": "3",
                         "type": "user",
                         "attributes": {
                           "email": "0@mail.com",
                           "username": "User000",
-                          "created_at": "2022-04-16T18:56:55.390Z",
+                          "created_at": "2022-04-17T10:02:31.188Z",
                           "role": {
                             "name": "unconfirmed",
                             "value": -30
@@ -1180,12 +1218,12 @@
                     "type": "auth",
                     "attributes": {
                       "me": {
-                        "id": "5",
+                        "id": "6",
                         "type": "user",
                         "attributes": {
                           "email": "user_3@example.com",
-                          "username": "Hephaestus78058",
-                          "created_at": "2022-04-16T18:56:55.482Z",
+                          "username": "Hades53848",
+                          "created_at": "2022-04-17T10:02:31.258Z",
                           "role": {
                             "name": "user",
                             "value": 0
@@ -1314,22 +1352,22 @@
         "parameters": [],
         "responses": {
           "200": {
-            "description": "instructions sent",
+            "description": "password reset successfully",
             "content": {
               "application/json": {
                 "example": {
                   "data": {
                     "type": "auth",
                     "attributes": {
-                      "access_token": "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOjcsImV4cCI6MTY1MDEzOTAxNSwianRpIjoiNDNkOWRiMDE4NGRhZmRjNTI1NzIyNDk1NzRiMDg2ZjkiLCJ0eXBlIjoiYWNjZXNzIn0.exl6SgX0UF-UvjsQgUa8Pl3VnCGR_unJXlWX0nd6Sow",
-                      "refresh_token": "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOjcsImV4cCI6MTY1MjcyNzQxNSwianRpIjoiNDNkOWRiMDE4NGRhZmRjNTI1NzIyNDk1NzRiMDg2ZjkiLCJ0eXBlIjoicmVmcmVzaCJ9.9tbDXlTJCxtwvFRBvhPdCSd_QTF26hB7ECKN5WpTS1o",
+                      "access_token": "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOjgsImV4cCI6MTY1MDE5MzM1MSwianRpIjoiMmNmZjk0NGE1YWQyY2Q4ZjM4NDQzOThkNzk3NzhiNDgiLCJ0eXBlIjoiYWNjZXNzIn0.Tk8a8DVpWh2gTEow4juYTdIRqxZjIURjalmT_w7tTO8",
+                      "refresh_token": "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOjgsImV4cCI6MTY1Mjc4MTc1MSwianRpIjoiMmNmZjk0NGE1YWQyY2Q4ZjM4NDQzOThkNzk3NzhiNDgiLCJ0eXBlIjoicmVmcmVzaCJ9.ax_7EcRe5fOfIVVjkYbekiCLRWcW7-NF3dNJpen868Q",
                       "me": {
-                        "id": "7",
+                        "id": "8",
                         "type": "user",
                         "attributes": {
                           "email": "user_5@example.com",
-                          "username": "Demeter52204",
-                          "created_at": "2022-04-16T18:56:55.551Z",
+                          "username": "Hermes19109",
+                          "created_at": "2022-04-17T10:02:31.336Z",
                           "role": {
                             "name": "admin",
                             "value": 50
@@ -1435,14 +1473,14 @@
                       "id": "1",
                       "type": "post",
                       "attributes": {
-                        "body": "Aut dolorem omnis. Rerum dicta qui.",
-                        "created_at": "2022-04-16T18:56:55.640Z",
-                        "updated_at": "2022-04-16T18:56:55.640Z"
+                        "body": "Nihil magnam consequatur. Eveniet et facere.",
+                        "created_at": "2022-04-17T10:02:31.513Z",
+                        "updated_at": "2022-04-17T10:02:31.513Z"
                       },
                       "relationships": {
                         "user": {
                           "data": {
-                            "id": "9",
+                            "id": "10",
                             "type": "user"
                           }
                         }
@@ -1452,14 +1490,14 @@
                       "id": "2",
                       "type": "post",
                       "attributes": {
-                        "body": "Quia alias ut. Dolore pariatur dolor.",
-                        "created_at": "2022-04-16T18:56:55.668Z",
-                        "updated_at": "2022-04-16T18:56:55.668Z"
+                        "body": "Et quia magnam. Quia quae excepturi.",
+                        "created_at": "2022-04-17T10:02:31.523Z",
+                        "updated_at": "2022-04-17T10:02:31.523Z"
                       },
                       "relationships": {
                         "user": {
                           "data": {
-                            "id": "10",
+                            "id": "11",
                             "type": "user"
                           }
                         }
@@ -1497,14 +1535,14 @@
                     "id": "4",
                     "type": "post",
                     "attributes": {
-                      "body": "Velit facere non. Dolor itaque enim.",
-                      "created_at": "2022-04-16T18:56:55.764Z",
-                      "updated_at": "2022-04-16T18:56:55.764Z"
+                      "body": "Dolor iure ut. Repellat eos nihil.",
+                      "created_at": "2022-04-17T10:02:31.551Z",
+                      "updated_at": "2022-04-17T10:02:31.551Z"
                     },
                     "relationships": {
                       "user": {
                         "data": {
-                          "id": "11",
+                          "id": "12",
                           "type": "user"
                         }
                       }
@@ -1598,14 +1636,14 @@
                     "id": "7",
                     "type": "post",
                     "attributes": {
-                      "body": "Eius dolor eum. Molestias qui tempore.",
-                      "created_at": "2022-04-16T18:56:55.825Z",
-                      "updated_at": "2022-04-16T18:56:55.825Z"
+                      "body": "Neque deleniti voluptates. Dolor molestiae voluptatibus.",
+                      "created_at": "2022-04-17T10:02:31.610Z",
+                      "updated_at": "2022-04-17T10:02:31.610Z"
                     },
                     "relationships": {
                       "user": {
                         "data": {
-                          "id": "14",
+                          "id": "15",
                           "type": "user"
                         }
                       }
@@ -1661,14 +1699,14 @@
                     "id": "8",
                     "type": "post",
                     "attributes": {
-                      "body": "Qui quidem occaecati. Blanditiis officia voluptas. | updated!",
-                      "created_at": "2022-04-16T18:56:55.847Z",
-                      "updated_at": "2022-04-16T18:56:55.856Z"
+                      "body": "Aspernatur enim sit. Aut quod laborum. | updated!",
+                      "created_at": "2022-04-17T10:02:31.631Z",
+                      "updated_at": "2022-04-17T10:02:31.640Z"
                     },
                     "relationships": {
                       "user": {
                         "data": {
-                          "id": "15",
+                          "id": "16",
                           "type": "user"
                         }
                       }
@@ -1677,6 +1715,50 @@
                 },
                 "schema": {
                   "$ref": "#/components/schemas/response_post"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "unauthorized",
+            "content": {
+              "application/json": {
+                "example": {
+                  "errors": [
+                    {
+                      "code": "unauthorized",
+                      "status": "401",
+                      "title": "Unauthorized",
+                      "detail": [
+                        "You must be logged in"
+                      ]
+                    }
+                  ]
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "forbidden user",
+            "content": {
+              "application/json": {
+                "example": {
+                  "errors": [
+                    {
+                      "code": "forbidden",
+                      "status": "403",
+                      "title": "Unauthorized",
+                      "detail": [
+                        "not allowed to update? this Post"
+                      ]
+                    }
+                  ]
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/error"
                 }
               }
             }
@@ -1752,17 +1834,17 @@
               "application/json": {
                 "example": {
                   "data": {
-                    "id": "10",
+                    "id": "12",
                     "type": "post",
                     "attributes": {
-                      "body": "Nam beatae praesentium. Rerum repellendus iusto. | updated!",
-                      "created_at": "2022-04-16T18:56:55.899Z",
-                      "updated_at": "2022-04-16T18:56:55.909Z"
+                      "body": "Quasi et rerum. Sint officia ex. | updated!",
+                      "created_at": "2022-04-17T10:02:31.734Z",
+                      "updated_at": "2022-04-17T10:02:31.742Z"
                     },
                     "relationships": {
                       "user": {
                         "data": {
-                          "id": "17",
+                          "id": "21",
                           "type": "user"
                         }
                       }
@@ -1771,6 +1853,50 @@
                 },
                 "schema": {
                   "$ref": "#/components/schemas/response_post"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "unauthorized",
+            "content": {
+              "application/json": {
+                "example": {
+                  "errors": [
+                    {
+                      "code": "unauthorized",
+                      "status": "401",
+                      "title": "Unauthorized",
+                      "detail": [
+                        "You must be logged in"
+                      ]
+                    }
+                  ]
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "forbidden user",
+            "content": {
+              "application/json": {
+                "example": {
+                  "errors": [
+                    {
+                      "code": "forbidden",
+                      "status": "403",
+                      "title": "Unauthorized",
+                      "detail": [
+                        "not allowed to update? this Post"
+                      ]
+                    }
+                  ]
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/error"
                 }
               }
             }
@@ -1842,12 +1968,12 @@
                 "example": {
                   "data": [
                     {
-                      "id": "19",
+                      "id": "26",
                       "type": "user",
                       "attributes": {
-                        "email": "user_17@example.com",
-                        "username": "Demeter71613",
-                        "created_at": "2022-04-16T18:56:55.980Z",
+                        "email": "user_23@example.com",
+                        "username": "Hestia17049",
+                        "created_at": "2022-04-17T10:02:31.836Z",
                         "role": {
                           "name": "user",
                           "value": 0
@@ -1855,12 +1981,12 @@
                       }
                     },
                     {
-                      "id": "20",
+                      "id": "27",
                       "type": "user",
                       "attributes": {
-                        "email": "user_18@example.com",
-                        "username": "Apollo19482",
-                        "created_at": "2022-04-16T18:56:55.987Z",
+                        "email": "user_24@example.com",
+                        "username": "Zeus63206",
+                        "created_at": "2022-04-17T10:02:31.842Z",
                         "role": {
                           "name": "user",
                           "value": 0
@@ -1901,12 +2027,12 @@
               "application/json": {
                 "example": {
                   "data": {
-                    "id": "21",
+                    "id": "28",
                     "type": "user",
                     "attributes": {
-                      "email": "user_19@example.com",
-                      "username": "Dionysus90788",
-                      "created_at": "2022-04-16T18:56:56.008Z",
+                      "email": "user_25@example.com",
+                      "username": "Artemis78365",
+                      "created_at": "2022-04-17T10:02:31.864Z",
                       "role": {
                         "name": "user",
                         "value": 0
@@ -1969,12 +2095,12 @@
               "application/json": {
                 "example": {
                   "data": {
-                    "id": "22",
+                    "id": "29",
                     "type": "user",
                     "attributes": {
-                      "email": "user_20@example.com",
+                      "email": "user_26@example.com",
                       "username": "NewGreatUsername1",
-                      "created_at": "2022-04-16T18:56:56.030Z",
+                      "created_at": "2022-04-17T10:02:31.903Z",
                       "role": {
                         "name": "user",
                         "value": 0
@@ -2112,12 +2238,12 @@
               "application/json": {
                 "example": {
                   "data": {
-                    "id": "27",
+                    "id": "34",
                     "type": "user",
                     "attributes": {
-                      "email": "user_25@example.com",
+                      "email": "user_31@example.com",
                       "username": "NewGreatUsername1",
-                      "created_at": "2022-04-16T18:56:56.127Z",
+                      "created_at": "2022-04-17T10:02:32.004Z",
                       "role": {
                         "name": "user",
                         "value": 0

--- a/spec/requests/.rubocop.yml
+++ b/spec/requests/.rubocop.yml
@@ -5,3 +5,6 @@ Layout/SpaceBeforeBrackets:
 
 RSpec/VariableName:
   Enabled: false
+
+Metrics/BlockLength:
+  Max: 500

--- a/spec/requests/api/v1/auth_spec.rb
+++ b/spec/requests/api/v1/auth_spec.rb
@@ -30,6 +30,32 @@ RSpec.describe 'api/v1/auth', type: :request do
         end
         include_context 'with swagger test'
       end
+
+      response 401, 'invalid credentials' do
+        schema '$ref' => '#/components/schemas/invalid_credentials_error'
+
+        let!(:user) { create(:user, :with_user_role, :with_known_data) }
+        let(:data) do
+          {
+            data: {
+              type: 'auth',
+              attributes: {
+                email: user.email
+              }
+            }
+          }
+        end
+        include_context 'with swagger test'
+      end
+
+      response 422, 'param is missing' do
+        schema '$ref' => '#/components/schemas/param_is_missing'
+
+        let(:data) do
+          { data: { type: 'auth' } }
+        end
+        include_context 'with swagger test'
+      end
     end
   end
 
@@ -201,7 +227,7 @@ RSpec.describe 'api/v1/auth', type: :request do
         '$ref' => '#/components/schemas/parameter_reset_password'
       }
 
-      response 200, 'instructions sent' do
+      response 200, 'password reset successfully' do
         schema '$ref' => '#/components/schemas/auth'
 
         let!(:user) { create :user, :with_admin_role, :with_reset_token }

--- a/spec/requests/api/v1/posts_spec.rb
+++ b/spec/requests/api/v1/posts_spec.rb
@@ -122,6 +122,36 @@ RSpec.describe 'api/v1/posts', type: :request do
           include_context 'with swagger test'
         end
 
+        response 401, 'unauthorized' do
+          schema '$ref' => '#/components/schemas/error'
+
+          let!(:user) { create(:user, :with_user_role) }
+          let!(:post) { create(:post, user: user) }
+          let(:Authorization) { 'Bearer 123' }
+
+          let(:id) { post.id }
+          let(:data) do
+            { data: { type: 'post', attributes: { body: 'post' } } }
+          end
+          include_context 'with swagger test'
+        end
+
+        response 403, 'forbidden user' do
+          schema '$ref' => '#/components/schemas/error'
+
+          let!(:user) { create(:user, :with_user_role) }
+          let!(:another_user) { create(:user, :with_user_role) }
+
+          let!(:post) { create(:post, user: another_user) }
+          let(:Authorization) { ApiHelper.authenticated_header(user: user) }
+
+          let(:id) { post.id }
+          let(:data) do
+            { data: { type: 'post', attributes: { body: 'post' } } }
+          end
+          include_context 'with swagger test'
+        end
+
         response 404, 'post not found' do
           schema '$ref' => '#/components/schemas/error'
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [x] Tests Update

## Description

- Monkey patch `Pundit` `authorize` method to use own `AuthError` type with `error_code`;
- Improve error handling for `Auth::BasicAuthError`;
- Toughen `JSON:API` params to require `type` and `attributes`;
- Update ayth and user request specs;
- Add guide for app authentication & authorization;
